### PR TITLE
feat: add support for SchallCircuitGroup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: ????
+  Changes:
+    - [item=production-combinator] Changed subgroup to circuit-input if SchallCircuitGroup mod is present.
+    - [item=consumption-combinator] Changed subgroup to circuit-input if SchallCircuitGroup mod is present.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,2 @@
+-- Better subgroup placement with SchallCircuitGroup
+require("data-updates.schall-circuit-group")

--- a/data-updates/schall-circuit-group.lua
+++ b/data-updates/schall-circuit-group.lua
@@ -1,0 +1,4 @@
+if mods["SchallCircuitGroup"] then
+  data.raw.item["production-combinator"].subgroup = "circuit-input"
+  data.raw.item["consumption-combinator"].subgroup = "circuit-input"
+end


### PR DESCRIPTION
- [item=production-combinator] Changed subgroup to circuit-input if SchallCircuitGroup mod is present.
- [item=consumption-combinator] Changed subgroup to circuit-input if SchallCircuitGroup mod is present.